### PR TITLE
Fix the issue of sidebar being cut off vertically

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -117,6 +117,9 @@
 }
 
 /* General styles */
+#browser {
+    position: relative;
+}
 #sidebar-box #sidebar-header {
     visibility: collapse;
     display: none;
@@ -124,36 +127,32 @@
 
 #sidebar-box:not([hidden]) {
     display: block;
-    position: fixed;
+    position: absolute;
     min-width: 48px;
     max-width: 48px;
     overflow: hidden;
     transition: all 0.2s ease;
     border-right: 1px solid var(--sidebar-border-color);
     z-index: 1;
+    top: 0;
+    bottom: 0;
 }
 
 #sidebar,
 #sidebar-box:hover {
-    min-width: 20vw !important;
-    max-width: 20vw !important;
+    min-width: 220px !important;
+    max-width: 220px !important;
 }
 
-@media (width >= 1200px) {
-    #sidebar,
-    #sidebar-box:hover {
-          min-width: 10vw !important;
-          max-width: 10vw !important;
-      }
-}
 
 #sidebar-splitter {
     display: none;
 }
 
 #sidebar {
-    height: calc(100vh - 32px);
+    max-height: 100%;
 }
+
 
 #sidebar-box:not([hidden]) ~ #appcontent {
     margin-left: 48px;

--- a/userChrome.css
+++ b/userChrome.css
@@ -140,8 +140,16 @@
 
 #sidebar,
 #sidebar-box:hover {
-    min-width: 220px !important;
-    max-width: 220px !important;
+    min-width: 20vw !important;
+    max-width: 20vw !important;
+}
+
+@media (width >= 1200px) {
+    #sidebar,
+    #sidebar-box:hover {
+          min-width: 10vw !important;
+          max-width: 10vw !important;
+      }
 }
 
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -159,6 +159,7 @@
 
 #sidebar {
     max-height: 100%;
+    height: 100%;
 }
 
 


### PR DESCRIPTION
When in Normal & Touch densities, the new tab button would cut off:
![2021-07-11_18-49](https://user-images.githubusercontent.com/40742947/125212250-07d1a780-e27a-11eb-8109-228195612141.png)

This should fix that: 
![2021-07-11_18-59](https://user-images.githubusercontent.com/40742947/125212270-33ed2880-e27a-11eb-9658-02ce30b7e0a0.png)
