### PR TITLE
Fix the style of URL bar

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -189,3 +189,12 @@
 #sidebar-close {
     filter: invert(100%);
 }
+
+@media (max-width: 630px) {
+    #urlbar-container {
+        min-width: 100% !important;
+    }
+    #menubar-items {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
### My environment
- Firefox 90.0 (64-bit) on macOS v11.4
- Firefox 90.0 (64-bit) on Windows 10 v2004

### Something not good with the style of the URL bar
When the width of browser window is the smallest zoomable size, the URL bar will look like this.

**macOS**
<img width="450" alt="1" src="https://user-images.githubusercontent.com/9015538/126074762-10bd78a3-b414-48f3-867f-685d651ee360.png">

**Windows**
<img width="450" alt="2" src="https://user-images.githubusercontent.com/9015538/126074802-4c1742b9-6e5c-4f5a-a0d5-38552fe5817c.png">

This is both on Windows and macOS.

### The way to fix
- On macOS: Just set the `min-width` value of `#urlbar-container`.
- On Windows: Based on the method used on macOS, I tried but the style is still not good. Then I found that there is a useless `#menubar-items` on the left that takes up space. This may be due to the Windows control (maximize, etc.) button on the right?

Therefore, I added the following code.

```css
@media (max-width: 630px) {
    #urlbar-container {
        min-width: 100% !important;
    }
    #menubar-items {
        display: none !important;
    }
}
```

This is the result.

**macOS**
<img width="450" alt="3" src="https://user-images.githubusercontent.com/9015538/126075097-396448cf-eb01-4440-80b3-0ba7f96725d7.png">

**Windows**
<img width="450" alt="4" src="https://user-images.githubusercontent.com/9015538/126075126-49dfe21b-69e2-4d27-9ca7-613a7d8b9bdd.png">


