### PR TITLE
Hides the windows controls on the left side of the toolbar.

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -67,6 +67,7 @@
           border-right-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-width,0px));
 
           padding-top: 0px !important;
+          margin-left: -80px; /* Removes the space left when hiding .titlebar-buttonbox-container */
       }
 
     :root {
@@ -81,7 +82,14 @@
     #TabsToolbar {
           visibility: collapse !important;
       }
-
+    /* Hide the Windows controls on the left side. */
+    #TabsToolbar .titlebar-buttonbox-container {
+          visibility: hidden !important;
+      }
+    /* Line up the Windows controls with the rest of the icons in the toolbar. */
+    .titlebar-buttonbox-container {
+          margin-top: 7px;
+      }
     :root:not([inFullscreen]) #nav-bar {
           margin-top: calc(0px - var(--uc-toolbar-height));
       }


### PR DESCRIPTION
By default on Windows 10, the toolbar had the Windows controls on both the right and left side of the toolbar.
This change hides the controls on the left hand side of the toolbar.
The nav-bar then is moved to the left so the back button is now lined up with the left edge of the browser.

![image](https://user-images.githubusercontent.com/23690/127715288-11174c22-06ae-4146-bf4c-479d626408cd.png)
