### PR TITLE
Change mox prefix properties

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,7 @@
 * Firefox Vertical Tabs
-Vertical tabs for Firefox, inspired by Edge. Works with Light theme, Dark theme, and System theme (auto dark mode). There are some minor glitches with Alpenglow, but they should be easy to fix.
+Vertical tabs for Firefox, inspired by Edge. Works with Light theme, Dark theme,
+and System theme (auto dark mode). There are some minor glitches with Alpenglow
+but they should be easy to fix.
 
 It also plays nice with Container Tabs.
 
@@ -9,22 +11,41 @@ It also plays nice with Container Tabs.
 [[./screenshots/macos.png]]
 
 ** Compatibility
-Guarateed compatibility with Firefox 93. It should work on newer versions as well unless there's any breaking changes in how ~userChrome.css~ works, but I can
+Guarateed compatibility with Firefox 99. There has recently been in change in
+Firefox that requires the use of ~-moz-platform~ instead of ~-moz-os-version~ to
+use OS-specific CSS. This will work from 99.0b1 upwards but might not on older
+versions, so be aware of that. If you run an older version of Firefox and have
+an issue, change this back.
 
-I have only tested this for Linux and macOS. There might be some bugs on Windows because the window decorations look different. I can't test this because I don't have a Windows computer, but if you find any bugs and know how to fix it, feel free to submit a PR.
+(Also, since the only OS-specific CSS in the file targets Windows, it should not
+affect you on Mac or Linux either way.)
+
+It should work on newer versions as well unless there's any breaking changes in
+how ~userChrome.css~ works.
+
+I have only tested this for Linux and macOS. There might be some bugs on Windows
+because the window decorations look different. I can't test this because I don't
+have a Windows computer, but if you find any bugs and know how to fix it, feel
+free to submit a PR.
 
 ** How to install
-- Go to ~about:config~ in your URL bar, search for ~toolkit.legacyUserProfileCustomizations.stylesheets~ and set it to ~true~.
-- Go to ~about:profiles~ in your URL bar, click /"Open Directory"/ next to your Root Directory under your default profile.
+- Go to ~about:config~ in your URL bar, search for
+  ~toolkit.legacyUserProfileCustomizations.stylesheets~ and set it to ~true~.
+- Go to ~about:profiles~ in your URL bar, click /"Open Directory"/ next to your Root
+  Directory under your default profile.
 - If there is no ~chrome~ folder, create it.
 - Create a file called ~userChrome.css~ inside the ~chrome~ folder.
 - Copy and paste the contents of ~userChrome.css~ into your file (or symlink it).
 - Install the [[https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/][Tab Center Reborn]] extension.
-- Make sure to enable /"Allow this extension to run in Private windows"/ so you're not left stranded while browsing.
-- Go to ~about:addons~ in your URL bar, select *Tab Center Reborn*, go to *Preferences* and set:
+- Make sure to enable /"Allow this extension to run in Private windows"/ so you're
+  not left stranded while browsing.
+- Go to ~about:addons~ in your URL bar, select *Tab Center Reborn*, go to
+  *Preferences* and set:
   - *Animations*: on.
   - *Use current browser theme*: on, if you want to use dark mode.
-  - *Compact Mode*: either /"Dynamic"/ or /"Enabled"/. It works with /"Disabled"/ too but looks nicer with only favicons.
+  - *Compact Mode*: either /"Dynamic"/ or /"Enabled"/. It works with /"Disabled"/ too
+    but looks nicer with only favicons.
   - *Favicon-only pinned tabs*: off.
-  - Activate *Custom Stylesheet* and paste the contents of ~tabCenterReborn.css~ into the text area below, and click /"Save CSS"/ under the text box.
+  - Activate *Custom Stylesheet* and paste the contents of ~tabCenterReborn.css~
+    into the text area below, and click /"Save CSS"/ under the text box.
 - Restart Firefox.

--- a/userChrome.css
+++ b/userChrome.css
@@ -55,7 +55,7 @@
 
 
 /* Windows specific styles */
-@media (-moz-os-version: windows-win10) { 
+@media (-moz-platform: windows-win10) {
     /* Hide main tabs toolbar */
     :root[tabsintitlebar]{
           --uc-window-control-width: 138px; /* Space at the right of nav-bar for window controls */


### PR DESCRIPTION
With FF v99.0b1 onward, OS-specific CSS now works with `-moz-platform` instead of `-moz-os-version`. This PR fixes that and ensures compatibility with FF 99 and newer.

Might break on older versions.