### PR TITLE
Fix a bug with sidebar hovering

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -52,6 +52,10 @@
     margin-left: auto;
 }
 
+#settings-icon {
+    visibility: hidden;
+}
+
 #tablist-wrapper {
     height: auto;
     margin: 0 6px;
@@ -99,7 +103,8 @@
 }
 
 /* Show more when hovering over the sidebar */
-body:hover #tablist-wrapper .tab-title-wrapper {
+body:hover #tablist-wrapper .tab-title-wrapper,
+body:hover #settings-icon {
     visibility: visible;
 }
 
@@ -107,8 +112,6 @@ body #newtab::after {
     content: "New tab";
     visibility: hidden;
     margin-left: 10px;
-    transition: all 0.2s ease;
-    transition-delay: 200ms;
 }
 
 body:hover #newtab::after {

--- a/userChrome.css
+++ b/userChrome.css
@@ -145,6 +145,11 @@
     display: none;
 }
 
+[sidebarcommand*="tabcenter"] #sidebar {
+    min-width: 48px !important;
+    max-width: 48px !important;
+}
+
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
     position: absolute;
@@ -158,7 +163,7 @@
     bottom: 0;
 }
 
-[sidebarcommand*="tabcenter"] #sidebar,
+[sidebarcommand*="tabcenter"] #sidebar:hover,
 #sidebar-box[sidebarcommand*="tabcenter"]:hover {
     min-width: 10vw !important;
     width: 30vw !important;
@@ -167,7 +172,7 @@
 }
 
 @media (width >= 1200px) {
-    [sidebarcommand*="tabcenter"] #sidebar,
+    [sidebarcommand*="tabcenter"] #sidebar:hover,
     #sidebar-box[sidebarcommand*="tabcenter"]:hover {
         max-width: 250px !important;
     }


### PR DESCRIPTION
This will fix an issue where hovering next to the sidebar triggered some of the
events. I had to make the whole sidebar, not just the container that contains
its contents, smaller and expand that on hover.

This comes with a caveat: the animations that happens inside TCR (like slowly
fading in the names of the tabs and hidind the settings icon) don't work because
they are not just hidden away by overflow now but, because the size of the whole
box changes, they would wrap around. So they have to become invisible
immediately and not after a delay. The animations therefore looks a bit less
smooth now.

Should fix #29 