### PR TITLE
Add option for delay before expanding the sidebar.

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,7 @@ free to submit a PR.
 - If there is no ~chrome~ folder, create it.
 - Create a file called ~userChrome.css~ inside the ~chrome~ folder.
 - Copy and paste the contents of ~userChrome.css~ into your file (or symlink it).
+- OPTIONAL: Adjust ~--delay~ setting in the ~userChrome.css~ and ~tabCenterReborn.css~ files.
 - Install the [[https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/][Tab Center Reborn]] extension.
 - Make sure to enable /"Allow this extension to run in Private windows"/ so you're
   not left stranded while browsing.

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -3,6 +3,10 @@
     --tab-separator: transparent;
     --tab-selected-line: transparent;
     --tablist-separator: #cccccc;
+    /* delay before expanding tabs, set to '0' for no delay */
+    --delay: 0.5s;
+    /* fix scrolling bug when collapsed */
+    overflow: hidden;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -81,7 +85,7 @@
     margin-right: 4px;
     margin-left: 2px;
     padding-left: 9px;
-    min-width: 80px;
+    min-width: 36px;
     width: 100%;
 }
 
@@ -112,12 +116,18 @@ body:hover #settings-icon {
 
 body #newtab::after {
     content: "New tab";
-    visibility: hidden;
+    visibility: collapse;
     margin-left: 10px;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 body:hover #newtab::after {
     visibility: visible;
+}
+
+#newtab-icon {
+    min-width: 16px;
 }
 
 body:hover #tablist-wrapper::after,
@@ -182,4 +192,23 @@ body:hover #pinnedtablist:not(.compact) .tab {
 #tablist .tab.active[data-identity-color] .tab-context::before {
     top: 1px;
     bottom: 1px;
+}
+
+/* used for delay function */
+body:not(:hover) .tab-close {
+    visibility: collapse !important;
+}
+
+#settings-icon,
+#newtab::after,
+#tablist-wrapper .tab-title-wrapper,
+.tab-close {
+    transition: visibility 0s linear var(--delay);
+}
+
+body:not(:hover) #settings-icon,
+body:not(:hover) #newtab::after,
+body:not(:hover) #tablist-wrapper .tab-title-wrapper,
+body:not(:hover) .tab-close {
+    transition: visibility 0s linear 0s;
 }

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -70,8 +70,11 @@
     max-width: 34px;
     margin: 2px 0;
     border: 1px solid var(--tablist-separator);
-    transition: all 0.2s ease;
-    transition-delay: 200ms;
+    transition: all 0.2s ease var(--delay);
+}
+
+body:not(:hover) #tablist-wrapper::after {
+    transition: all 0.2s ease 0s;
 }
 
 #tablist-wrapper .tab-title-wrapper {

--- a/userChrome.css
+++ b/userChrome.css
@@ -1,3 +1,8 @@
+:root {
+    /* delay before expanding tabs, set to '0' for no delay */
+    --delay: 0.5s;
+}
+
 /* Linux & macOS specific styles */
 @media (-moz-gtk-csd-available), (-moz-mac-big-sur-theme: 0), (-moz-mac-big-sur-theme: 1) {
     #TabsToolbar:not([customizing="true"]) {
@@ -169,7 +174,6 @@
     min-width: 48px;
     max-width: 48px;
     overflow: hidden;
-    transition: all 0.2s ease;
     border-right: 1px solid var(--sidebar-border-color);
     z-index: 1;
     top: 0;
@@ -182,6 +186,13 @@
     width: 30vw !important;
     max-width: 200px !important;
     z-index: 10 !important;
+    transition: all 0.2s ease var(--delay);
+}
+
+/* used for delay function */
+[sidebarcommand*="tabcenter"] #sidebar:not(:hover),
+#sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) {
+    transition: all 0.2s ease 0s;
 }
 
 @media (width >= 1200px) {


### PR DESCRIPTION
Adds an option for a delay (using `transition-delay`) before expanding the sidebar. This allows a user to quickly change tabs without expanding the full sidebar. To expand the sidebar just have the mouse located inside the sidebar area for more than 0.5s (by default, delay can be easily adjusted).

To disable the delay just set the `--delay` variable to `0` inside the `userChrome.css` and `tabCenterReborn.css` files.

This also replicates the Edge behaviour more closely.

https://user-images.githubusercontent.com/62812711/182325896-327c7adf-7e30-424d-849a-088d0c1cd24c.mov

Also fixes some minor issues with the transition when expanding the sidebar (mostly relating to the 'New Tab' text.)