### PR TITLE
fix items disappearing when context menu is open (and other improvements)

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ free to submit a PR.
 - If there is no ~chrome~ folder, create it.
 - Create a file called ~userChrome.css~ inside the ~chrome~ folder.
 - Copy and paste the contents of ~userChrome.css~ into your file (or symlink it).
-- OPTIONAL: Adjust ~--delay~ setting in the ~userChrome.css~ and ~tabCenterReborn.css~ files.
+- OPTIONAL: Adjust ~--delay~ setting in the ~userChrome.css~ file.
 - Install the [[https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/][Tab Center Reborn]] extension.
 - Make sure to enable /"Allow this extension to run in Private windows"/ so you're
   not left stranded while browsing.

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -3,8 +3,6 @@
     --tab-separator: transparent;
     --tab-selected-line: transparent;
     --tablist-separator: #cccccc;
-    /* delay before expanding tabs, set to '0' for no delay */
-    --delay: 0.5s;
     /* fix scrolling bug when collapsed */
     overflow: hidden;
 }
@@ -56,31 +54,23 @@
     margin-left: auto;
 }
 
-#settings-icon {
-    visibility: hidden;
-}
-
 #tablist-wrapper {
     height: auto;
-    margin: 0 6px;
+    margin-inline: 6px;
+    /* adds margin above tabs to make the spacing even */
+    margin-top: 5px;
+}
+
+/* fix glitch with spacing in-between pinned tabs */
+#pinnedtablist:not(.compact) {
+    display: flex;
+    flex-direction: column;
 }
 
 #tablist-wrapper::after {
     content: "";
-    max-width: 34px;
     margin: 2px 0;
     border: 1px solid var(--tablist-separator);
-    transition: all 0.2s ease var(--delay);
-}
-
-body:not(:hover) #tablist-wrapper::after {
-    transition: all 0.2s ease 0s;
-}
-
-#tablist-wrapper .tab-title-wrapper {
-    visibility: hidden;
-    transition: all 0.2s ease;
-    transition-delay: 200ms;
 }
 
 #newtab {
@@ -95,11 +85,9 @@ body:not(:hover) #tablist-wrapper::after {
 
 .tab,
 .tab.active {
-    max-width: 36px;
     border-radius: 4px;
     border-bottom: none !important;
     margin: 1px 0;
-    transition: max-width 12s ease;
 }
 
 #pinnedtablist:not(.compact) .tab,
@@ -107,63 +95,43 @@ body:not(:hover) #tablist-wrapper::after {
     padding: 0;
 }
 
-#pinnedtablist:not(.compact) .tab {
-    padding-left: 6px;
-}
-
-/* Show more when hovering over the sidebar */
-body:hover #tablist-wrapper .tab-title-wrapper,
-body:hover #settings-icon {
-    visibility: visible;
-}
-
-body #newtab::after {
+#newtab::after {
     content: "New tab";
-    visibility: collapse;
     margin-left: 10px;
     white-space: nowrap;
     overflow: hidden;
-}
-
-body:hover #newtab::after {
-    visibility: visible;
 }
 
 #newtab-icon {
     min-width: 16px;
 }
 
-body:hover #tablist-wrapper::after,
-body:hover .tab {
-    max-width: 100%;
+
+/* the @media rule only allows these settings apply when the sidebar is expanded */
+@media (min-width: 49px) {
+    /* Move close button to left side */
+    /*.tab-close {
+        left: 0;
+        margin-left: 3px;
+    }*/
+
+    /* Fix title gradient */
+    /*#tablist .tab:hover > .tab-title-wrapper {
+        mask-image: linear-gradient(to left, transparent 0, black 2em);
+    }*/
+
+    /* Move tab text to right when hovering to accomodate for the close button */
+    /*#tablist .tab:hover > .tab-title-wrapper {
+        margin-left: 28px;
+        transition: all 0.2s ease;
+    }*/
+
+    /* Move favicon to right when hovering to accomodate for the close button */
+    /*#tablist .tab:hover > .tab-meta-image {
+        padding-left: 25px;
+        transition: all 0.2s ease;
+    }*/
 }
-
-body:hover #pinnedtablist:not(.compact) .tab {
-    padding-left: 0;
-}
-
-/* Move close button to left side */
-/*.tab-close {
-    left: 0;
-    margin-left: 3px;
-}*/
-
-/* Fix title gradient */
-/*#tablist .tab:hover > .tab-title-wrapper {
-    mask-image: linear-gradient(to left, transparent 0, black 2em);
-}*/
-
-/* Move tab text to right when hovering to accomodate for the close button */
-/*#tablist .tab:hover > .tab-title-wrapper {
-    margin-left: 28px;
-    transition: all 0.2s ease;
-}*/
-
-/* Move favicon to right when hovering to accomodate for the close button */
-/*#tablist .tab:hover > .tab-meta-image {
-    padding-left: 25px;
-    transition: all 0.2s ease;
-}*/
 
 
 /*** Move container indicators to left ***/
@@ -171,17 +139,20 @@ body:hover #pinnedtablist:not(.compact) .tab {
     margin-left: 0px;
     padding-left: 6px;
 }
-#tablist {
+#tablist,
+#pinnedtablist:not(.compact) {
     margin-left: -6px;
     padding-left: 6px;
 }
 .tab {
     overflow: visible;
 }
-#tablist .tab[data-identity-color] .tab-context {
+#tablist .tab[data-identity-color] .tab-context,
+#pinnedtablist:not(.compact) .tab[data-identity-color] .tab-context {
     box-shadow: none !important;
 }
-#tablist .tab[data-identity-color] .tab-context::before {
+#tablist .tab[data-identity-color] .tab-context::before,
+#pinnedtablist:not(.compact) .tab[data-identity-color] .tab-context::before {
     content: "";
     position: absolute;
     top: 6px;
@@ -192,26 +163,35 @@ body:hover #pinnedtablist:not(.compact) .tab {
     background: var(--identity-color);
     transition: inset .1s;
 }
-#tablist .tab.active[data-identity-color] .tab-context::before {
+#tablist .tab.active[data-identity-color] .tab-context::before,
+#pinnedtablist:not(.compact) .tab.active[data-identity-color] .tab-context::before {
     top: 1px;
     bottom: 1px;
 }
 
-/* used for delay function */
-body:not(:hover) .tab-close {
-    visibility: collapse !important;
+/* center favicons within the tab */
+#tablist-wrapper.shrinked>:not(#pinnedtablist.compact) .tab-meta-image {
+    margin-left: 6px !important;
 }
 
-#settings-icon,
-#newtab::after,
-#tablist-wrapper .tab-title-wrapper,
-.tab-close {
-    transition: visibility 0s linear var(--delay);
+/* hide certain items when collapsed */
+@media (max-width: 64px) {
+    /* using 64px minimum width to give the tab favicons more room during the transition */
+    .tab-close,
+    .tab-pin {
+        visibility: collapse !important;
+    }
+
+    /* hide scrollbar when sidebar is collapsed */
+    #tablist {
+        scrollbar-width: none;
+    }
 }
 
-body:not(:hover) #settings-icon,
-body:not(:hover) #newtab::after,
-body:not(:hover) #tablist-wrapper .tab-title-wrapper,
-body:not(:hover) .tab-close {
-    transition: visibility 0s linear 0s;
+@media (max-width: 48px) {
+    #settings-icon,
+    #tablist-wrapper .tab-title-wrapper,
+    #newtab::after {
+        visibility: hidden !important;
+    }
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -1,6 +1,7 @@
 :root {
     /* delay before expanding tabs, set to '0' for no delay */
     --delay: 0.5s;
+    --transition-time: 0.2s;
 }
 
 /* Linux & macOS specific styles */
@@ -171,6 +172,7 @@
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
     position: absolute;
+    box-sizing: content-box;
     min-width: 48px;
     max-width: 48px;
     overflow: hidden;
@@ -180,23 +182,23 @@
     bottom: 0;
 }
 
-[sidebarcommand*="tabcenter"] #sidebar:hover,
+#sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
 #sidebar-box[sidebarcommand*="tabcenter"]:hover {
     min-width: 10vw !important;
     width: 30vw !important;
     max-width: 200px !important;
     z-index: 10 !important;
-    transition: all 0.2s ease var(--delay);
+    transition: all var(--transition-time) ease var(--delay);
 }
 
 /* used for delay function */
-[sidebarcommand*="tabcenter"] #sidebar:not(:hover),
+#sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) #sidebar,
 #sidebar-box[sidebarcommand*="tabcenter"]:not(:hover) {
-    transition: all 0.2s ease 0s;
+    transition: all var(--transition-time) ease 0s;
 }
 
 @media (width >= 1200px) {
-    [sidebarcommand*="tabcenter"] #sidebar:hover,
+    #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
     #sidebar-box[sidebarcommand*="tabcenter"]:hover {
         max-width: 250px !important;
     }


### PR DESCRIPTION
This should fix issue #5 by removing all of the `:hover` rules, and using `@media (min-width)` rules to detect when the sidebar is collapsed, so the tab labels will only be hidden when the extension window is 48px wide or less:

![context-menu](https://user-images.githubusercontent.com/62812711/182621563-95bfc8dc-c3e6-45ac-917d-dcdc607252dd.png)

Other improvements include:

The `#sidebar` and `#sidebar-box` transitions are tied together, which can prevent a glitch where if you hover the mouse over the border you can expand the `#sidebar-box` element, but not the extension window:

![sidebar-glitch](https://user-images.githubusercontent.com/62812711/182622839-39a5d09a-e79b-4283-850f-4af72e7f2e28.png)

The container indicator will be displayed on the left for pinned tabs (like normal tabs):

![pinned-tabs](https://user-images.githubusercontent.com/62812711/182623632-d61612c4-3f30-43a1-b7f4-6e81fb739aca.png)

Some alignment/spacing improvements:
 - move the tab favicon into the center of the tab (was 1px to the left before)
 - add `box-sizing: content-box` to the `#sidebar-box` element. This ensures that the sidebar (when collapsed) is `48px` + the border/separator width. (Before the tab sidebar was only 47px wide due to the border.)
 - add a margin to the top of the tabs to make the spacing at the top even with the sides:

![margin-top](https://user-images.githubusercontent.com/62812711/182625127-53ff651f-48d6-487e-82a2-038b9eb2052f.png)

