### PR TITLE
Add a border to sidebar in light theme.

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -156,8 +156,8 @@
     /* Line up the Windows controls with the rest of the icons in the toolbar. */
     .titlebar-buttonbox-container {
         margin-top: 3px;
-        }
-    
+    }
+
 
     :root:not([inFullscreen]) #nav-bar {
         margin-top: calc(0px - var(--uc-toolbar-height));
@@ -212,6 +212,10 @@
 
 #nav-bar, #urlbar {
     z-index: 100;
+}
+
+#sidebar-box:not([lwt-sidebar]){
+    appearance: unset !important;
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"] {


### PR DESCRIPTION
This makes it more consistent because the dark theme also has it, plus it it
sometimes hard to see wherer the sidebar ends when there is no indicator.