### PR TITLE
Additional comments

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -5,11 +5,11 @@
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
-    margin-left: 0px; /* '48px' for left sidebar */
+    margin-left: 48px; /* '0px' for right sidebar */
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
-    position: none; /* 'absolute' for left sidebar */
+    position: absolute; /* 'none' for right sidebar */
 }
 
 /* macOS specific styles */

--- a/userChrome.css
+++ b/userChrome.css
@@ -5,11 +5,11 @@
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
-    margin-left: 48px; /* '0px' for right sidebar */
+    margin-left: 48px; /* '0px' for right, '48px' for left sidebar */
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
-    position: absolute; /* 'none' for right sidebar */
+    position: absolute; /* 'none' for right, 'absolute' for left sidebar */
 }
 
 /* macOS specific styles */

--- a/userChrome.css
+++ b/userChrome.css
@@ -4,6 +4,14 @@
     --transition-time: 0.2s;
 }
 
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
+    margin-left: 0px; /* '48px' for left sidebar */
+}
+
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
+    position: none; /* 'absolute' for left sidebar */
+}
+
 /* macOS specific styles */
 @media (-moz-platform: macos) {
     #TabsToolbar:not([customizing="true"]) {
@@ -123,12 +131,12 @@
 @media (-moz-platform: windows-win10) {
     /* Hide main tabs toolbar */
     :root[tabsintitlebar]{
-        --uc-window-control-width: 105px; /* Space at the right of nav-bar for window controls */
+        --uc-window-control-width: 137px; /* Space at the right of nav-bar for window controls */
         /* --uc-window-drag-space-width: 24px; */  /* To add extra window drag space in nav-bar */
     }
 
     #nav-bar{
-        border-inline: var(--uc-window-drag-space-width,0px) solid var(--toolbar-bgcolor) ;
+        border-inline: var(--uc-window-drag-space-width,80px) solid var(--toolbar-bgcolor) ;
         border-inline-style: solid !important;
         border-right-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-width,0px));
 
@@ -234,7 +242,6 @@
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
-    position: absolute;
     box-sizing: content-box;
     min-width: 48px;
     max-width: 48px;
@@ -274,10 +281,6 @@
 [sidebarcommand*="tabcenter"] #sidebar {
     max-height: 100%;
     height: 100%;
-}
-
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
-    margin-left: 48px;
 }
 
 #main-window[inFullscreen][inDOMFullscreen] #appcontent {

--- a/userChrome.css
+++ b/userChrome.css
@@ -2,14 +2,8 @@
     /* delay before expanding tabs, set to '0' for no delay */
     --delay: 0.5s;
     --transition-time: 0.2s;
-}
-
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
-    margin-left: 48px; /* '0px' for right, '48px' for left sidebar */
-}
-
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
-    position: absolute; /* 'none' for right, 'absolute' for left sidebar */
+    --positionX1: 0px; /* '48px' for left, '0px' for right sidebar */
+    --positionX2: none; /* 'absolute' for left, 'none' for right sidebar */
 }
 
 /* macOS specific styles */
@@ -242,6 +236,7 @@
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
+    position: var(--positionX2);
     box-sizing: content-box;
     min-width: 48px;
     max-width: 48px;
@@ -281,6 +276,10 @@
 [sidebarcommand*="tabcenter"] #sidebar {
     max-height: 100%;
     height: 100%;
+}
+
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
+    margin-left: var(-positionX1);
 }
 
 #main-window[inFullscreen][inDOMFullscreen] #appcontent {

--- a/userChrome.css
+++ b/userChrome.css
@@ -2,8 +2,8 @@
     /* delay before expanding tabs, set to '0' for no delay */
     --delay: 0.5s;
     --transition-time: 0.2s;
-    --positionX1: 0px; /* '48px' for left, '0px' for right sidebar */
-    --positionX2: none; /* 'absolute' for left, 'none' for right sidebar */
+    --positionX1: 48px; /* '48px' for left, '0px' for right sidebar */
+    --positionX2: absolute; /* 'absolute' for left, 'none' for right sidebar */
 }
 
 /* macOS specific styles */


### PR DESCRIPTION
Hi, Microsoft Edge by default allows vertical tabs only on the left, which is annoying for some Windows users (including me) who have the system window buttons on the right. 

At the top of `userChrome.css` file, I have commented out the values for having the vertical tabs on the left and right for all OS, leaving default value.