### PR TITLE
Add missing dash to variable name

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -279,7 +279,7 @@
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
-    margin-left: var(-positionX1);
+    margin-left: var(--positionX1);
 }
 
 #main-window[inFullscreen][inDOMFullscreen] #appcontent {


### PR DESCRIPTION
This fixes an issue where no padding was applied to the content window
when the sidebar is active.