### PR TITLE
Make uppermost rightmost pixel close Firefox in Windows

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -174,11 +174,11 @@
 
     .titlebar-buttonbox {
         z-index:3 !important;
-        padding-right:3px;
+        /* padding-right:3px; */
     }
 
     .titlebar-buttonbox * {
-        border-radius: 5px;
+        /* border-radius: 5px; */
         width:35px;
         height:38px;
     }

--- a/userChrome.css
+++ b/userChrome.css
@@ -172,7 +172,7 @@
         position: relative;
     }
 
-    /* For a rounded button design, remove two comments in .titlebar-buttonbox. */
+    /* For a rounded button design, uncomment both lines in .titlebar-buttonbox. */
     .titlebar-buttonbox {
         z-index:3 !important;
         /* padding-right:3px; */

--- a/userChrome.css
+++ b/userChrome.css
@@ -172,6 +172,7 @@
         position: relative;
     }
 
+    /* For a rounded button design, remove two comments in .titlebar-buttonbox. */
     .titlebar-buttonbox {
         z-index:3 !important;
         /* padding-right:3px; */


### PR DESCRIPTION
This gets rid of the rounded aesthetic for titlebar buttons, but brings this .CSS in line with common behavior for Windows, especially for those coming from Edge - dragging your mouse to the uppermost and rightmost pixel closes the Firefox window.