### PR TITLE
Windows: make it possible to drag the maximized window by its top ledge.

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -134,9 +134,29 @@
         border-inline-style: solid !important;
         border-right-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-width,0px));
 
-        padding-top: 0px !important;
+        padding-top: .5px !important; /* This makes it possible to drag the maximized window. */
         margin-left: -80px; /* Removes the space left when hiding .titlebar-buttonbox-container */
     }
+    
+    #back-button { 
+		margin-top: -.5px !important; 
+	}
+	
+	#forward-button { 
+		margin-top: -.5px !important; 
+	}
+	
+	#reload-button { 
+		margin-top: -.5px !important; 
+	}
+    
+	#PanelUI-button {
+		margin-top: -.5px !important; 
+	}
+    
+	#nav-bar-overflow-button{
+		margin-top: -.5px !important; 
+	}
 
     :root {
         --uc-toolbar-height: 32px;

--- a/userChrome.css
+++ b/userChrome.css
@@ -135,6 +135,7 @@
         border-right-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-width,0px));
 
         padding-top: .5px !important; /* This makes it possible to drag the maximized window. */
+	padding-bottom: .5px !important; 
         margin-left: -80px; /* Removes the space left when hiding .titlebar-buttonbox-container */
     }
     

--- a/userChrome.css
+++ b/userChrome.css
@@ -135,7 +135,6 @@
         border-right-width: calc(var(--uc-window-control-width,0px) + var(--uc-window-drag-space-width,0px));
 
         padding-top: .5px !important; /* This makes it possible to drag the maximized window. */
-	padding-bottom: .5px !important; 
         margin-left: -80px; /* Removes the space left when hiding .titlebar-buttonbox-container */
     }
     


### PR DESCRIPTION
In Edge and stock Firefox, there is that _one_ offset pixel on the top which you could use to drag the whole window around when it is maximized (without affecting neither rightmost close pixel nor leftmost back button pixel). This adds a minimally visually intrusive half-pixel ledge which makes this behavior possible as well. Back, forward, reload, Overflow and hamburger buttons need to be offset back half a pixel to make them be responsive to uppermost ledge - an important convenience function as it reduces a degree of precision required to access these buttons. 

_Unfortunately_, I can't seem to figure out a way to make this also work when the window is not maximized, which is not a problem in Edge as they make the ledge much bigger in unmaximized mode... If I figure that out I might make a final separate pull request.