### PR TITLE
Hide settings button

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -43,15 +43,11 @@
     margin-right: 2px;
 }
 
-/* Hide filterbox */
+/* Hide filterbox & settings icon */
 #filterbox-icon,
-#filterbox-input {
-    display: none;
-}
-
-/* Right-align settings icon */
+#filterbox-input,
 #settings {
-    margin-left: auto;
+    display: none;
 }
 
 #tablist-wrapper {
@@ -75,13 +71,12 @@
 
 #newtab {
     flex-grow: 1;
-    margin-right: 4px;
+    margin-right: 2px;
     margin-left: 2px;
     padding-left: 9px;
     min-width: 36px;
     width: 100%;
 }
-
 
 .tab,
 .tab.active {


### PR DESCRIPTION
I doubt this button is really used much at all, so I personally think it's best to just hide it. Since people can just access it through Firefox's addons page, anyways.

If you disagree, feel free to reject this pull request. 
![image](https://user-images.githubusercontent.com/40742947/186958424-dcdeaf45-9e54-4207-94d6-ee04a53ef49d.png)
