### PR TITLE
fix middle click newtab

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -254,7 +254,7 @@ comment out the @media line below and its closing bracket */
     margin-bottom: -100vh;
 }
 
-/* moves the separator to the original position */
+/* moves the new tab button separator to the original position */
 #tablist-wrapper::after {
     transform: translateY(-100vh);
 }

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -241,3 +241,21 @@ comment out the @media line below and its closing bracket */
         left: 16px !important;
     }
 }
+
+/* middle click newtab workaround */
+
+/* allows the #spacer element to take up more space */
+#spacer {
+    min-height: 100vh;
+}
+
+/* moves the new tab button to the original position */
+#tablist-wrapper {
+    margin-bottom: -100vh;
+}
+
+/* moves the separator to the original position */
+#tablist-wrapper::after {
+    transform: translateY(-100vh);
+}
+


### PR DESCRIPTION
This should fix issue #62

This is the element tree, you can see there is a `#tablist-wrapper` and inside it, there is a `#spacer` element.

![Screen Shot 2022-08-31 at 00 43 00](https://user-images.githubusercontent.com/62812711/187493519-7c78596d-fe36-4b6e-b91e-4d380084e74d.png)

The `#spacer` element is responsible for the middle click event. By setting `height: auto` on the `#tablist-wrapper`, that causes the `#spacer` element to completely collapse, as it has a `flex-basis: 0` and a `flex-grow: 1` (which basically means, take any remaining space after the other content), but the `height: auto` was preventing the `#spacer` from growing.

Removing the `height: auto` will fix the issue but you will be left with a gap between the newtab button and the tabs.

![image](https://user-images.githubusercontent.com/62812711/187489700-93481949-debc-449e-a92d-abc0370fe18b.png)


What this CSS does, is it sets a `min-height: 100vh` on the `#spacer` then uses a `margin-bottom: -100vh` on the `#tablist-wrapper` to move the newtab button back in position. The newtab button separator has a margin on it already so I used `translateY(-100vh)` to move it back.

I'm unaware of any side effects but based on some quick testing everything seems to work (including scrolling)

https://user-images.githubusercontent.com/62812711/187491990-2cf31223-99be-4968-a636-d0a02deac03a.mov