### PR TITLE
Autoscrolling bug fix

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,7 +59,3 @@ free to submit a PR.
 - In Fullscreen mode, the sidebar will collapse to a 1px wide border instead to
   be as unintrusive as possible. You can expand it by pushing your cursor all
   the way to the edge of the screen.
-- In the sidebar, you can open a new tab by double clicking or middle-clicking
-  into empty space. There is currently a bug that prevents middle-clicking to
-  work when you have Firefox's "autoscrolling" feature enabled (you can find it
-  in the preferences in the "Browsing" section).

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -3,8 +3,6 @@
     --tab-separator: transparent;
     --tab-selected-line: transparent;
     --tablist-separator: #cccccc;
-    /* fix scrolling bug when collapsed */
-    overflow: hidden;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -26,6 +24,12 @@
         --identity-color-toolbar: rgb(251,251,254);
         --tablist-separator: #333333;
     }
+}
+
+/* fix autoscrolling bug when middle clicking */
+:root,
+body {
+    overflow: hidden;
 }
 
 /* Move topmenu to bottom */


### PR DESCRIPTION
This should *hopefully* fix the autoscrolling bug by applying `overflow: hidden` to the body as well as the `:root` element.

Also removes the issue from the readme file, since this isn't an issue anymore.

I think the issue happened because the `body` still had an overflowing element that wasn't clipped off, so even though scrolling was disabled from the `:root` element, the browser thought it could still scroll the `body` element and the autoscrolling popup displayed.

I've tested this on both Windows and macOS with autoscrolling enabled and it works.