### PR TITLE
The expanded vertical tab should stay behind the suggestion box from search bar

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -286,7 +286,7 @@
     min-width: 10vw !important;
     width: 30vw !important;
     max-width: 200px !important;
-    z-index: 10 !important;
+    z-index: 1 !important;
     transition: all var(--transition-time) ease var(--delay);
 }
 


### PR DESCRIPTION
Currently the suggestion box was hidden behind the expanded vertical tab which kinda ruin the aesthetic

![comparision](https://user-images.githubusercontent.com/35302594/190842435-376a75cb-440d-486f-b432-0cf2bd150740.png)
