### PR TITLE
Fix sidebar overlaying content in fullscreen

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,6 +38,7 @@ free to submit a PR.
 - Create a file called ~userChrome.css~ inside the ~chrome~ folder.
 - Copy and paste the contents of ~userChrome.css~ into your file (or symlink it).
 - OPTIONAL: Adjust ~--delay~ setting in the ~userChrome.css~ file.
+- OPTIONAL: Adjust ~--fullscreen-sidebar-width~ setting in the ~userChrome.css~ file.
 - Install the [[https://addons.mozilla.org/en-US/firefox/addon/tabcenter-reborn/][Tab Center Reborn]] extension.
 - Make sure to enable /"Allow this extension to run in Private windows"/ so you're
   not left stranded while browsing.
@@ -58,5 +59,6 @@ free to submit a PR.
   general.
 - In Fullscreen mode, the sidebar will collapse to a 1px wide border instead to
   be as unintrusive as possible. You can expand it by pushing your cursor all
-  the way to the edge of the screen.
+  the way to the edge of the screen. This can be disabled by setting
+  ~--fullscreen-sidebar-width~ to ~48px~.
 - If your window controls are not correctly aligned, disable compact mode at =Customize toolbar...= menu.

--- a/userChrome.css
+++ b/userChrome.css
@@ -320,7 +320,7 @@
     margin-left: var(--positionX1);
 }
 
-#main-window[inFullscreen] #appcontent {
+#main-window[inFullscreen] #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
     margin-left: var(--fullscreen-sidebar-width);
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -4,6 +4,8 @@
     --transition-time: 0.2s;
     --positionX1: 48px; /* '48px' for left, '0px' for right sidebar */
     --positionX2: absolute; /* 'absolute' for left, 'none' for right sidebar */
+    /* width of the collapsed sidebar in fullscreen mode ('1px' or '48px') */
+    --fullscreen-sidebar-width: 1px;
 }
 
 /* macOS specific styles */
@@ -268,7 +270,6 @@
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
     position: var(--positionX2);
-    box-sizing: content-box;
     min-width: 48px;
     max-width: 48px;
     overflow: hidden;
@@ -278,9 +279,10 @@
     bottom: 0;
 }
 
-#main-window[inFullscreen] #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
-    min-width: 1px;
-    max-width: 1px;
+/* use :where() selector to lower specificity */
+:where(#main-window[inFullscreen]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
+    min-width: var(--fullscreen-sidebar-width) !important;
+    max-width: var(--fullscreen-sidebar-width) !important;
 }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
@@ -318,8 +320,8 @@
     margin-left: var(--positionX1);
 }
 
-#main-window[inFullscreen][inDOMFullscreen] #appcontent {
-    margin-left: 0;
+#main-window[inFullscreen] #appcontent {
+    margin-left: var(--fullscreen-sidebar-width);
 }
 
 #main-window[inFullscreen] #sidebar {


### PR DESCRIPTION
Fixes #78. This was caused by the solution to the changes brought in Firefox 107. Adding the `!important` flag caused the max-width value of the sidebar to be set to `48px`, and overwriting the fullscreen rules.

I also added an easy way to disable the fullscreen functionality by setting `--fullscreen-sidebar-width` to `48px` inside `userChrome.css`. This will cause the sidebar to have the same collapsed width in fullscreen mode as it does in windowed mode.