### PR TITLE
Don't show sidebar area when webpage is in fullscreen

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -320,7 +320,7 @@
     margin-left: var(--positionX1);
 }
 
-#main-window[inFullscreen] #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
+#main-window[inFullscreen]:not([inDOMFullscreen]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
     margin-left: var(--fullscreen-sidebar-width);
 }
 


### PR DESCRIPTION
I just realised that I introduced a bug with the last pull request that would cause space for the sidebar to be made when a webpage went into fullscreen mode (eg. watching a Youtube video in fullscreen), even though the sidebar would be hidden.

Example:
![Screen Shot 2022-12-07 at 19 50 18](https://user-images.githubusercontent.com/62812711/206172268-5ef97651-7fb6-468c-9edd-f28e0187ee44.png)

As you can see on the left there is a grey section that should be hidden.
