### PR TITLE
Fixes wrong GTK colors in the header bar

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -29,6 +29,11 @@
 
 /* Linux/GTK specific styles */
 @media (-moz-gtk-csd-available) {
+    .browser-toolbar:not(.titlebar-color){ /* Fixes wrong coloring applied with --toolbar-bgcolor by Firefox (#101) */
+        background-color: transparent !important;
+        box-shadow: none !important;
+    }
+
     #TabsToolbar:not([customizing="true"]) {
         visibility: collapse !important;
     }


### PR DESCRIPTION
As shown in #101, this commit aims to fix the wrong coloring that is applied by Firefox on `--toolbar-bgcolor` for GTK