### PR TITLE
feat: expanded tab hit area

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -96,6 +96,16 @@ body {
     padding: 0;
 }
 
+#pinnedtablist:not(.compact) .tab:before,
+#tablist .tab:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -6px;
+    width: 6px;
+}
+
 #newtab::after {
     content: "New tab";
     margin-left: 10px;


### PR DESCRIPTION
The hit area for tabs is stretched to the left. This allows it to fit close to the edge of the screen. This makes it easier to hit tabs. This is the same as with regular tabs, where the hit area is close to the top of the screen.


Before:

https://github.com/ranmaru22/firefox-vertical-tabs/assets/1662812/c8181f20-7105-4015-bd3f-43de83badd86

After:


https://github.com/ranmaru22/firefox-vertical-tabs/assets/1662812/499efbce-3c9b-40f3-92af-b206d08f1bda

