### PR TITLE
fix: expand window controls hit area

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -191,7 +191,7 @@
         visibility: hidden !important;
     }
     /* Line up the Windows controls with the rest of the icons in the toolbar. */
-    .titlebar-buttonbox-container {
+    :root:not([sizemode="maximized"]) .titlebar-buttonbox-container {
         margin-top: 3px;
     }
 


### PR DESCRIPTION
Currently, the window control buttons are indented 3 pixels from the edge of the screen. This is not in line with the Windows control model, where the window control buttons are always adjacent to the screen edge when the window is maximized.

This PR fix this. 

Before:

https://github.com/ranmaru22/firefox-vertical-tabs/assets/1662812/a953264f-3681-4c4d-851c-fb27b9aca5ee

After:


https://github.com/ranmaru22/firefox-vertical-tabs/assets/1662812/e7befcdf-8575-4fbc-b7f3-3056a62bbfbc




