### PR TITLE
fix: "New tab" text respect browser language

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -97,7 +97,7 @@ body {
 }
 
 #newtab::after {
-    content: "New tab";
+    content: attr(title);
     margin-left: 10px;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Instead of hard-coded `"New tab"` text for creating new tab button used built-in hint text that respect browser language.