### PR TITLE
fix: show reorder feedback

### DIFF
--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -84,16 +84,31 @@ body {
     width: 100%;
 }
 
-.tab,
-.tab.active {
-    border-radius: 4px;
-    border-bottom: none !important;
-    margin: 1px 0;
-}
-
 #pinnedtablist:not(.compact) .tab,
 #tablist .tab {
     padding: 0;
+    border: 0 solid transparent;
+    margin: 0;
+    background: transparent;
+}
+
+.tab:not(.active):hover .tab-drag-overlay {
+    border-radius: 4px;
+    background-color: var(--tab-hover-background);
+}
+
+#pinnedtablist:not(.compact) .tab.drag-highlight-next,
+#tablist .tab.drag-highlight-next {
+    border-bottom-width: var(--tab-height-compact);
+    height: calc(var(--tab-height-compact) * 2) !important;
+    max-height: calc(var(--tab-height-normal) + var(--tab-height-compact)) !important;
+}
+
+#pinnedtablist:not(.compact) .tab.drag-highlight-previous,
+#tablist .tab.drag-highlight-previous {
+    border-top-width: var(--tab-height-compact);
+    height: calc(var(--tab-height-compact) * 2) !important;
+    max-height: calc(var(--tab-height-normal) + var(--tab-height-compact)) !important;
 }
 
 #pinnedtablist:not(.compact) .tab:before,

--- a/tabCenterReborn.css
+++ b/tabCenterReborn.css
@@ -92,9 +92,17 @@ body {
     background: transparent;
 }
 
-.tab:not(.active):hover .tab-drag-overlay {
+.tab .tab-drag-overlay {
     border-radius: 4px;
+    z-index: -1;
+}
+
+.tab:not(.active):hover .tab-drag-overlay {
     background-color: var(--tab-hover-background);
+}
+
+.tab.active .tab-drag-overlay {
+    background-color: var(--tab-active-background);
 }
 
 #pinnedtablist:not(.compact) .tab.drag-highlight-next,


### PR DESCRIPTION
Restores feedback to the user when he drags a tab.

https://github.com/ranmaru22/firefox-vertical-tabs/assets/1662812/38bd2ee9-d0fe-4c02-80ba-a351e36025ce

Minor changes:
- `:hover` and `.active` backgrounds applied to `.tab .tab-drag-overlay`. This is done to physically stretch the tab element, but not visually stretch it.
- Removed a few pixels of indentation between tabs. Without this, when trying to drag a tab into the rock space "between" the dragging elements, the ddo of the last tab was applied. This led to a terrible tripping of the entire interface


> **Note:**
> During the testing process, I encountered the fact that the CSS could not be saved because it was too long. 
> `Error: QuotaExceededError: storage.sync API call exceeded its quota limitations`
> I'm not sure if this is a problem with my repository or global. Maybe it makes sense to offer minified css?