### PR TITLE
fix: support new Windows media query in userChrome.css

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -137,7 +137,8 @@
 }
 
 /* Windows specific styles */
-@media (-moz-platform: windows-win10) {
+@media (-moz-platform: windows),
+       (-moz-platform: windows-win10) {
     /* Hide main tabs toolbar */
     :root[tabsintitlebar]{
         --uc-window-control-width: 137px; /* Space at the right of nav-bar for window controls */


### PR DESCRIPTION
The latest Firefox Nightly renames the Windows media query from `windows-win10` to just `windows`.

Issue: #112