### PR TITLE
fix: Hide Sidebar

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -267,8 +267,12 @@
 }
 
 [sidebarcommand*="tabcenter"] #sidebar,
-#sidebar-box[sidebarcommand*="tabcenter"] {
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block !important;
+}
+
+[sidebarcommand*="tabcenter"] #sidebar,
+#sidebar-box[sidebarcommand*="tabcenter"] {
     min-width: 48px !important;
     max-width: 48px !important;
     width: 48px;


### PR DESCRIPTION
Fix "Show/hide Tab Center Reborn" button, sidebar appearing in fullscreen mode.

`display: block !important` from #127 overrides `<vbox id=sidebar-box hidden=true>` set by the show/hide button. 

Tested with Firefox 117.0.1, Windows 11
