### PR TITLE
fix: include new Linux media query in userChrome.css

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -28,7 +28,8 @@
 }
 
 /* Linux/GTK specific styles */
-@media (-moz-gtk-csd-available) {
+@media (-moz-gtk-csd-available), 
+       (-moz-platform: linux) {
     .browser-toolbar:not(.titlebar-color){ /* Fixes wrong coloring applied with --toolbar-bgcolor by Firefox (#101) */
         background-color: transparent !important;
         box-shadow: none !important;


### PR DESCRIPTION
The Linux/GTK media query `-moz-gtk-csd-available` doesn't work on my Linux system with *Firefox Developer Edition 120.0b9*, but `-moz-platform: linux` does work as expected. I found that media query from [here](https://github.com/mozilla/gecko-dev/commit/5fed8de04b3de8bb7a213deb37150af18d0b3314#diff-314c90db7a8ea5667e97a1ff5079d02192246d424244fc9dcebd568f3e1c87e7).