### PR TITLE
fix: only apply styles if toolbar is not hidden (fixes #100)

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -267,15 +267,15 @@
     display: none;
 }
 
-[sidebarcommand*="tabcenter"] #sidebar,
-#sidebar-box[sidebarcommand*="tabcenter"] {
+#main-window:not([chromehidden~="toolbar"]) [sidebarcommand*="tabcenter"] #sidebar,
+#main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"] {
     display: block !important;
     min-width: 48px !important;
     max-width: 48px !important;
     width: 48px;
 }
 
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
+#main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     display: block;
     position: var(--positionX2);
     min-width: 48px;
@@ -288,13 +288,13 @@
 }
 
 /* use :where() selector to lower specificity */
-:where(#main-window[inFullscreen]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
+:where(#main-window[inFullscreen]:not([chromehidden~="toolbar"])) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) {
     min-width: var(--fullscreen-sidebar-width) !important;
     max-width: var(--fullscreen-sidebar-width) !important;
 }
 
-#sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
-#sidebar-box[sidebarcommand*="tabcenter"]:hover {
+#main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
+#main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:hover {
     min-width: 10vw !important;
     width: 30vw !important;
     max-width: 200px !important;
@@ -309,8 +309,8 @@
 }
 
 @media (width >= 1200px) {
-    #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
-    #sidebar-box[sidebarcommand*="tabcenter"]:hover {
+    #main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:hover #sidebar,
+    #main-window:not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:hover {
         max-width: 250px !important;
     }
 }
@@ -324,11 +324,11 @@
     height: 100%;
 }
 
-#main-window:not([inFullscreen]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
+#main-window:not([inFullscreen]):not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
     margin-left: var(--positionX1);
 }
 
-#main-window[inFullscreen]:not([inDOMFullscreen]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
+#main-window[inFullscreen]:not([inDOMFullscreen]):not([chromehidden~="toolbar"]) #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent {
     margin-left: var(--fullscreen-sidebar-width);
 }
 


### PR DESCRIPTION
This should fix issue #100 by hiding the side bar if Tab Center Reborn is active and the current window has the `chromehidden=toolbar` attribute set.

I'm not too sure if there is a neater way to do this (e.g. without spamming `#main-window:not([chromehidden~="toolbar"])` everywhere) or whether there is a better attribute I should target for this, but it seems to work with my minimal testing on Linux with GNOME on Wayland.

You can open a pop-up by pasting the below into console:
```js
window.open("about:blank", "Test", 'width=400,height=200,scrollbars=yes');
```



Before: 
![image](https://github.com/ranmaru22/firefox-vertical-tabs/assets/30280397/bbbd3c8d-9783-48ea-ae21-551d241638de)

After:
![image](https://github.com/ranmaru22/firefox-vertical-tabs/assets/30280397/f203cc66-36d9-4234-8373-781003defc83)
